### PR TITLE
Fix two latent bugs in export docs and hot-path label parsing

### DIFF
--- a/R/export.R
+++ b/R/export.R
@@ -9,7 +9,7 @@
 #' @param pretty If `TRUE`, formats JSON with indentation for readability.
 #' @param include Character vector specifying which analyses to include.
 #'   Options: "summary", "self_time", "total_time", "hot_lines", "memory",
-#'   "callers", "gc_pressure", "suggestions", "recursive". Default includes all.
+#'   "gc_pressure", "suggestions", "recursive". Default includes all.
 #' @param system_info If `TRUE`, includes R version and platform info in
 #'   metadata. Useful for reproducibility.
 #'

--- a/R/hot-paths.R
+++ b/R/hot-paths.R
@@ -118,7 +118,9 @@ pv_print_hot_paths <- function(x, n = 10, include_source = TRUE) {
     # Extract the leaf function from the hottest path (last in the chain)
     parts <- strsplit(paths$stack[1], " -> ")[[1]]
     # Remove source info if present: "func (file:line)" -> "func"
-    leaf_func <- sub(" \\(.*\\)$", "", parts[length(parts)])
+    # Anchor on the file:line shape rather than ".*", so labels that themselves
+    # contain " (" (e.g. "if (x > 1)") keep their parenthesised part.
+    leaf_func <- strip_location(parts[length(parts)])
     suggestions <- "pv_flame(p)"
     if (is_user_function(leaf_func)) {
       suggestions <- c(sprintf("pv_focus(p, \"%s\")", leaf_func), suggestions)

--- a/R/utils.R
+++ b/R/utils.R
@@ -140,6 +140,14 @@ cat_help_hint <- function() {
   cat("Run pv_help() to see all available functions.\n")
 }
 
+# Strip a trailing " (file:line)" suffix from a stack entry, leaving the label.
+# The location never contains spaces or parens and always ends in ":<digits>",
+# so anchoring on that shape is safe even when the label itself contains " (",
+# as in "if (x > 1) (file.R:3)". A greedy " \\(.*\\)$" would eat both parts.
+strip_location <- function(entry) {
+  sub(" \\([^ ()]+:[0-9]+\\)$", "", entry)
+}
+
 # Check if a function name is a user function (not internal R machinery)
 # Internal functions start with: ( like (top-level), < like <GC>, [ like [.data.frame
 is_user_function <- function(func_name) {

--- a/man/pv_to_json.Rd
+++ b/man/pv_to_json.Rd
@@ -23,7 +23,7 @@ JSON string.}
 
 \item{include}{Character vector specifying which analyses to include.
 Options: "summary", "self_time", "total_time", "hot_lines", "memory",
-"callers", "gc_pressure", "suggestions", "recursive". Default includes all.}
+"gc_pressure", "suggestions", "recursive". Default includes all.}
 
 \item{system_info}{If \code{TRUE}, includes R version and platform info in
 metadata. Useful for reproducibility.}

--- a/tests/testthat/test-export.R
+++ b/tests/testthat/test-export.R
@@ -34,6 +34,31 @@ test_that("pv_to_json respects include parameter", {
   expect_false(grepl("\"total_time\":", json_limited))
 })
 
+test_that("every documented include option is accepted", {
+  p <- pv_example()
+  opts <- eval(formals(pv_to_json)$include)
+
+  expect_equal(
+    opts,
+    c(
+      "summary",
+      "self_time",
+      "total_time",
+      "hot_lines",
+      "memory",
+      "gc_pressure",
+      "suggestions",
+      "recursive"
+    )
+  )
+  expect_equal(eval(formals(pv_to_list)$include), opts)
+
+  for (opt in opts) {
+    expect_no_error(pv_to_json(p, include = opt))
+    expect_no_error(pv_to_list(p, include = opt))
+  }
+})
+
 test_that("pv_to_json pretty parameter works", {
   p <- pv_example()
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -71,3 +71,14 @@ test_that("get_source_lines returns NULL when start > end after clamping", {
   result <- debrief:::get_source_lines("R/main.R", 10, 2, contents)
   expect_null(result)
 })
+
+test_that("strip_location keeps labels containing ' ('", {
+  expect_equal(strip_location("paste (analysis.R:22)"), "paste")
+  expect_equal(strip_location("if (x > 1) (file.R:3)"), "if (x > 1)")
+  expect_equal(
+    strip_location("data.frame(x = x, y = y) (analysis.R:11)"),
+    "data.frame(x = x, y = y)"
+  )
+  expect_equal(strip_location("plain_label"), "plain_label")
+  expect_equal(strip_location("f(a) (b)"), "f(a) (b)")
+})


### PR DESCRIPTION
Two unrelated bugs found while auditing debrief's output for machine readability, both of which bite a user following the documentation.

`pv_to_json()` and `pv_to_list()` documented an `include = "callers"` option that was never wired up, so using it errored in `match.arg()`. It can't be implemented as-is, since `pv_callers()` needs a function name that a whole-profile export has no way to supply, so the docs now match reality.

Separately, `pv_print_hot_paths()` used a greedy regex to strip the `" (file:line)"` suffix off a stack entry, which also swallowed any part of the label after an earlier `" ("`. Labels like `if (x > 1)` came back as `if`, and that truncated name feeds the `pv_focus(p, "...")` next-step suggestion, so the printed advice could name a function that doesn't exist.